### PR TITLE
Parse AVITI FASTQ headers

### DIFF
--- a/src/pyquest/readers/fq.py
+++ b/src/pyquest/readers/fq.py
@@ -36,13 +36,19 @@ ILLUMINA_SINGLE_FASTQ_HEADER_PATTERN = re.compile(r"^@([^\s/]+)$")
 ILLUMINA_FASTQ_HEADER_PATTERN = re.compile(r"^@(\S+)/([12])$")
 CASAVA_FASTQ_HEADER_PATTERN = re.compile(r"^@(\S+)\s([012]):([YN])+:[\d+]+:\S+$")
 
-# AVITI header similar to CASAVA but has optional pair member
-# @<name> <pair_member_or_empty>:<qc_flag>:<control>:<index>
+# AVITI header from Base2Fastq processing:
+# https://docs.elembio.io/docs/bases2fastq/outputs/#fastq-files
+# @<instrument>:<run name>:<flow cell ID>:<lane>:<tile>:<x-pos>:<y-pos>:UMI <read>:N:0:<index sequence>
+# where <read> is 1 or 2
+#
+# AVITI header is based on CASAVA pattern except for:
+# 1) Allows for read to missing. Observed in FASTQ header after Base2Fastq processing
+#    in some versions of Base2Fasta
+# 2) Assumes that the instrument starts with AV
 # For example
-# @<name> :<qc_flag>:<control>:<index>
-# @<name> 1:<qc_flag>:<control>:<index>
-AVITI_FASTQ_HEADER_PATTERN = re.compile(r"^@(\S+)\s+(?:([12])?:)([YN]):(\d+):(\S+)$")
-
+# @AV<name>  :N:0:<index sequence>
+# @AV<name> 1:N:0:<index sequence>
+AVITI_FASTQ_HEADER_PATTERN = re.compile(r"^@(AV\S+)\s+([12])?:([YN]):(\d+):(\S+)$")
 OFFSET_ILLUMINA = 64
 OFFSET_CASAVA = 33
 OFFSET_AVITI = 33
@@ -62,11 +68,11 @@ def _parse_fq_header(header: str):
         name = groups[0]
         pair_member = int(groups[1])
     elif (match := AVITI_FASTQ_HEADER_PATTERN.match(header)) is not None:
-        # AVITI format with optional pair_member
+        # AVITI format with missing read in header set to 1
         phred_offset = OFFSET_AVITI
         groups = match.groups()
         name = groups[0]
-        pair_member = int(groups[1]) if groups[1] is not None else None
+        pair_member = int(groups[1]) if groups[1] is not None else 1
         if groups[2] == "Y":
             qc_fail = True
     elif (match := CASAVA_FASTQ_HEADER_PATTERN.match(header)) is not None:

--- a/src/pyquest/readers/fq.py
+++ b/src/pyquest/readers/fq.py
@@ -36,9 +36,16 @@ ILLUMINA_SINGLE_FASTQ_HEADER_PATTERN = re.compile(r"^@([^\s/]+)$")
 ILLUMINA_FASTQ_HEADER_PATTERN = re.compile(r"^@(\S+)/([12])$")
 CASAVA_FASTQ_HEADER_PATTERN = re.compile(r"^@(\S+)\s([012]):([YN])+:[\d+]+:\S+$")
 
+# AVITI header similar to CASAVA but has optional pair member
+# @<name> <pair_member_or_empty>:<qc_flag>:<control>:<index>
+# For example
+# @<name> :<qc_flag>:<control>:<index>
+# @<name> 1:<qc_flag>:<control>:<index>
+AVITI_FASTQ_HEADER_PATTERN = re.compile(r"^@(\S+)\s+(?:([12])?:)([YN]):(\d+):(\S+)$")
 
 OFFSET_ILLUMINA = 64
 OFFSET_CASAVA = 33
+OFFSET_AVITI = 33
 
 
 def _parse_fq_header(header: str):
@@ -54,6 +61,14 @@ def _parse_fq_header(header: str):
         groups = match.groups()
         name = groups[0]
         pair_member = int(groups[1])
+    elif (match := AVITI_FASTQ_HEADER_PATTERN.match(header)) is not None:
+        # AVITI format with optional pair_member
+        phred_offset = OFFSET_AVITI
+        groups = match.groups()
+        name = groups[0]
+        pair_member = int(groups[1]) if groups[1] is not None else None
+        if groups[2] == "Y":
+            qc_fail = True
     elif (match := CASAVA_FASTQ_HEADER_PATTERN.match(header)) is not None:
         # casava1.8+ format
         phred_offset = OFFSET_CASAVA

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -22,7 +22,13 @@ import pysam
 
 from pyquest.readers.fq import get_fastq_read_info
 from pyquest.readers.hts import get_hts_read_info
-from pyquest.errors import InputReadError
+from pyquest.errors import InputReadError, InvalidFASTQError
+from pyquest.readers.fq import (
+    _parse_fq_header,
+    OFFSET_AVITI,
+    OFFSET_ILLUMINA,
+    OFFSET_CASAVA,
+)
 
 
 @pytest.mark.parametrize('seq,exp_discard', [
@@ -70,3 +76,40 @@ def test_get_hts_read_info_error():
 
     # Test hts read parsing throws error correctly
     pytest.raises(InputReadError, get_hts_read_info, 0, False, read)
+
+
+@pytest.mark.parametrize(
+    "header,exp_name,exp_pair,exp_qc,exp_phred",
+    [
+        ('@AVName1 1:N:0:ACGT', 'AVName1', 1, False, OFFSET_AVITI),
+        ('@AVName1  :N:0:ACGT', 'AVName1', 1, False, OFFSET_AVITI),
+        ('@Name1', 'Name1', None, False, OFFSET_ILLUMINA),
+        ('@Name1 1:N:0:ACGT', 'Name1', 1, False, OFFSET_CASAVA),
+    ]
+)
+def test_parse_fq_header_valid_input(
+    header: str,
+    exp_name: str,
+    exp_pair: int | None,
+    exp_qc: bool,
+    exp_phred: int,
+):
+
+    name, pair_member, qc_fail, phred_offset = _parse_fq_header(header)
+
+    assert name == exp_name
+    assert pair_member == exp_pair
+    assert qc_fail == exp_qc
+    assert phred_offset == exp_phred
+
+
+@pytest.mark.parametrize(
+    "header,expected_error",
+    [
+        ('@AVName1 3:N:0:ACGT', InvalidFASTQError),
+        ('@Name1 :N:0:ACGT', InvalidFASTQError),
+    ]
+)
+def test_parse_fq_header_error(header: str, expected_error: type[Exception]):
+    with pytest.raises(expected_error):
+        _parse_fq_header(header)


### PR DESCRIPTION
An update to parse AVITI FASTQ headers.

Previously AVITI FASTQ headers reported the following error

`ERROR: Unsupported FastQ header format:`